### PR TITLE
Updated container content to 'videos' for Embuary compatability

### DIFF
--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -196,7 +196,7 @@ def add_stream(name, link_url, title, game_id, epg, icon=None, fanart=None, info
         liz.addStreamInfo('audio', audio_info)
 
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=u, listitem=liz, isFolder=False)
-    xbmcplugin.setContent(addon_handle, 'tvshows')
+    xbmcplugin.setContent(addon_handle, 'videos')
 
     return ok
 
@@ -233,7 +233,7 @@ def add_fav_today(name, title, icon, fanart=None):
         liz.addStreamInfo('audio', audio_info)
 
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=liz, isFolder=False)
-    xbmcplugin.setContent(addon_handle, 'tvshows')
+    xbmcplugin.setContent(addon_handle, 'videos')
 
     return ok
 
@@ -262,7 +262,7 @@ def add_link(name, url, title, iconimage, info=None, video_info=None, audio_info
         liz.setProperty('fanart_image', FANART)
 
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=liz)
-    xbmcplugin.setContent(addon_handle, 'tvshows')
+    xbmcplugin.setContent(addon_handle, 'videos')
     return ok
 
 
@@ -286,7 +286,7 @@ def add_dir(name, url, mode, iconimage, fanart=None, game_day=None):
         liz.setProperty('fanart_image', FANART)
 
     ok = xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=u, listitem=liz, isFolder=True)
-    xbmcplugin.setContent(int(sys.argv[1]), 'tvshows')
+    xbmcplugin.setContent(int(sys.argv[1]), 'videos')
     return ok
 
 


### PR DESCRIPTION
Hi - Thanks so much for your work with this addon. I've been using it (and it has been working great) since before the switch over from gamecenter to nhl.tv. 

I currently use the embuary skin, and I noticed that when browsing the games in list view, instead of the thumb being the thumbnails generated by the add-on, the fanart would be shown. When I raised this issue with the dev of the skin, he mentioned that the since the add-on's container contents were set to tvshows rather than videos, his skin was showing the incorrect thumbs. 

As a result, he suggested that I make the below modifications to the globals.py to change the container type, and therefore allow embuary to show the correct thumbs in the skin. I have been running your addon with these changes since April of 2019 (and have made these changes to 2 updates you've released to your add-on), and have not encountered any issues. 

Rather than keep manually updating the globals.py after each update, I thought I would see if you would accept a pull request containing the changes. 

Here is a link to where the dev mentioned it in the nhl.tv thread in case you wanted a more technical answer (I just changed what was suggested):

https://forum.kodi.tv/showthread.php?tid=243756&pid=2843553#pid2843553

Thanks for your consideration!