### PR TITLE
allow greater flexibility in choosing which stream to watch

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -5,8 +5,12 @@ url = None
 name = None
 mode = None
 game_day = None
-home_id = None
-away_id = None
+stream1_id = None
+stream2_id = None
+stream3_id = None
+stream1_name = None
+stream2_name = None
+stream3_name = None
 highlight_id = None
 teams_stream = None
 stream_date = None
@@ -19,10 +23,18 @@ if "mode" in params:
     mode = int(params["mode"])
 if "game_day" in params:
     game_day = urllib.unquote_plus(params["game_day"])
-if "home_id" in params:
-    home_id = urllib.unquote_plus(params["home_id"])
-if "away_id" in params:
-    away_id = urllib.unquote_plus(params["away_id"])
+if "stream1_id" in params:
+    stream1_id = urllib.unquote_plus(params["stream1_id"])
+if "stream2_id" in params:
+    stream2_id = urllib.unquote_plus(params["stream2_id"])
+if "stream3_id" in params:
+    stream3_id = urllib.unquote_plus(params["stream3_id"])
+if "stream1_name" in params:
+    stream1_name = urllib.unquote_plus(params["stream1_name"])
+if "stream2_name" in params:
+    stream2_name = urllib.unquote_plus(params["stream2_name"])
+if "stream3_name" in params:
+    stream3_name = urllib.unquote_plus(params["stream3_name"])
 if "highlight_id" in params:
     highlight_id = urllib.unquote_plus(params["highlight_id"])
 
@@ -34,7 +46,7 @@ elif mode == 100 or mode == 101:
     todays_games(game_day)
 
 elif mode == 104:
-    stream_select(home_id, away_id, highlight_id)
+    stream_select(stream1_id, stream2_id, stream3_id, stream1_name, stream2_name, stream3_name, highlight_id)
 
 elif mode == 105:
     # Yesterday"s Games

--- a/resources/lib/game.py
+++ b/resources/lib/game.py
@@ -45,8 +45,7 @@ class Game:
         for item in self.content:
             if str(item["contentType"]["name"]).upper() == "FULL GAME" and len(item["clientContentMetadata"]):
                 broadcast = str(item["clientContentMetadata"][0]["name"]).upper()
-                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT"\
-                      or broadcast == "CBC" or broadcast == "ESPN" or broadcast == "ABC":
+                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT" or broadcast == "CBC":
                     self.home_id = str(item["id"])
                 elif broadcast == "AWAY":
                     self.away_id = str(item["id"])

--- a/resources/lib/game.py
+++ b/resources/lib/game.py
@@ -45,7 +45,7 @@ class Game:
         for item in self.content:
             if str(item["contentType"]["name"]).upper() == "FULL GAME" and len(item["clientContentMetadata"]):
                 broadcast = str(item["clientContentMetadata"][0]["name"]).upper()
-                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT":
+                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT" or broadcast == "CBC":
                     self.home_id = str(item["id"])
                 elif broadcast == "AWAY":
                     self.away_id = str(item["id"])

--- a/resources/lib/game.py
+++ b/resources/lib/game.py
@@ -45,7 +45,8 @@ class Game:
         for item in self.content:
             if str(item["contentType"]["name"]).upper() == "FULL GAME" and len(item["clientContentMetadata"]):
                 broadcast = str(item["clientContentMetadata"][0]["name"]).upper()
-                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT" or broadcast == "CBC":
+                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT"\
+                      or broadcast == "CBC" or broadcast == "ESPN" or broadcast == "ABC":
                     self.home_id = str(item["id"])
                 elif broadcast == "AWAY":
                     self.away_id = str(item["id"])

--- a/resources/lib/game.py
+++ b/resources/lib/game.py
@@ -8,8 +8,12 @@ class Game:
         self.home_team = game_json["homeCompetitor"]
         self.away_team = game_json["awayCompetitor"]
         self.content = game_json["content"]
-        self.home_id = ""
-        self.away_id = ""
+        self.stream1_id = ""
+        self.stream2_id = ""
+        self.stream3_id = ""
+        self.stream1_name = ""
+        self.stream2_name = ""
+        self.stream3_name = ""
         self.highlight_id = ""
 
     def create_listitem(self):
@@ -39,15 +43,21 @@ class Game:
 
         # add_stream(name, '', title, self.home_id, self.away_id, icon, fanart, info, video_info, audio_info)
 
-        add_stream(name, title, icon, fanart, info, home_id=self.home_id, away_id=self.away_id, highlight_id=self.highlight_id)
+        add_stream(name, title, icon, fanart, info, stream1_id=self.stream1_id, stream2_id=self.stream2_id, stream3_id=self.stream3_id, \
+                   stream1_name=self.stream1_name, stream2_name=self.stream2_name, stream3_name=self.stream3_name, highlight_id=self.highlight_id)
 
     def set_ids(self):
         for item in self.content:
             if str(item["contentType"]["name"]).upper() == "FULL GAME" and len(item["clientContentMetadata"]):
                 broadcast = str(item["clientContentMetadata"][0]["name"]).upper()
-                if broadcast == "HOME" or broadcast == "NATIONAL" or broadcast == "SPORTSNET" or broadcast == "TNT" or broadcast == "CBC":
-                    self.home_id = str(item["id"])
+                if broadcast == "HOME" or broadcast == "NATIONAL":
+                    self.stream1_id = str(item["id"])
+                    self.stream1_name = broadcast
                 elif broadcast == "AWAY":
-                    self.away_id = str(item["id"])
+                    self.stream2_id = str(item["id"])
+                    self.stream2_name = broadcast
+                else:
+                    self.stream3_id = str(item["id"])
+                    self.stream3_name = broadcast
             elif str(item["contentType"]["name"]).upper() == "HIGHLIGHTS":
                 self.highlight_id = str(item["id"])

--- a/resources/lib/nhl_tv.py
+++ b/resources/lib/nhl_tv.py
@@ -47,26 +47,31 @@ def todays_games(game_day):
 
     add_dir('[B]%s >>[/B]' % LOCAL_STRING(30011), '/live', 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"))
 
-def stream_select(home_id, away_id, highlight_id):
-    xbmc.log(f"home_id: {home_id}")
-    xbmc.log(f"away_id: {home_id}")
+def stream_select(stream1_id, stream2_id, stream3_id, stream1_name, stream2_name, stream3_name, highlight_id):
+    xbmc.log(f"stream1_id: {stream1_id}, stream1_name: {stream1_name}")
+    xbmc.log(f"stream2_id: {stream2_id}, stream2_name: {stream2_name}")
+    xbmc.log(f"stream3_id: {stream3_id}, stream3_name: {stream3_name}")
     xbmc.log(f"highlight_id: {highlight_id}")
 
-    options = ["National"]
-    if away_id != "":
-        options.remove("National")
-        options.append("Home")
-        options.append("Away")
+    options = []
+    if stream1_id != "":
+        options.append(stream1_name)
+    if stream2_id != "":
+        options.append(stream2_name)
+    if stream3_id != "":
+        options.append(stream3_name)
     if highlight_id != "":
         options.append("Highlights")
 
     dialog = xbmcgui.Dialog()
     n = dialog.select('Choose Stream', options)
     if n > -1:
-        if options[n] == "National" or options[n] == "Home":
-            id = home_id
-        elif options[n] == "Away":
-            id = away_id
+        if options[n] == stream1_name:
+            id = stream1_id
+        elif options[n] == stream2_name:
+            id = stream2_id
+        elif options[n] == stream3_name:
+            id = stream3_id
         elif options[n] == "Highlights":
             id = highlight_id
     else:


### PR DESCRIPTION
NHL TV doesn't just present "HOME" or "NATIONAL", and "AWAY" as stream options. It seems that there can be anywhere between one and three streams to choose from, and some of them are named after the network which broadcast them (or some other name). Here are a couple of examples from the nhltv web player
![Screenshot 2024-04-18 at 13-09-00 CALGARY FLAMES @ VANCOUVER CANUCKS](https://github.com/eracknaphobia/plugin.video.nhlgcl/assets/345478/be253de3-db13-4548-a2ce-9562bc326ee3)
![Screenshot 2024-04-18 at 14-51-30 VANCOUVER CANUCKS @ EDMONTON OILERS](https://github.com/eracknaphobia/plugin.video.nhlgcl/assets/345478/16171f7b-8c34-4563-bebe-191c09b2b6a8)
![Screenshot 2024-04-18 at 15-35-39 OTTAWA SENATORS @ BOSTON BRUINS](https://github.com/eracknaphobia/plugin.video.nhlgcl/assets/345478/eef9b6e0-bb36-4be3-9d83-6b567b1792be)

This pull request will allow for up to three streams to be presented (as well as highlights), and the name of the stream that is presented to the user will be pulled from the name of the stream in the nhltv api (so it should match the options presented in the web player).

This has the added bonus of presenting the FRENCH broadcast option when available, for our francophone nhl fans :-)