### PR TITLE
store stream names and ids in a dict

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -5,12 +5,7 @@ url = None
 name = None
 mode = None
 game_day = None
-stream1_id = None
-stream2_id = None
-stream3_id = None
-stream1_name = None
-stream2_name = None
-stream3_name = None
+stream_ids = None
 highlight_id = None
 teams_stream = None
 stream_date = None
@@ -23,18 +18,8 @@ if "mode" in params:
     mode = int(params["mode"])
 if "game_day" in params:
     game_day = urllib.unquote_plus(params["game_day"])
-if "stream1_id" in params:
-    stream1_id = urllib.unquote_plus(params["stream1_id"])
-if "stream2_id" in params:
-    stream2_id = urllib.unquote_plus(params["stream2_id"])
-if "stream3_id" in params:
-    stream3_id = urllib.unquote_plus(params["stream3_id"])
-if "stream1_name" in params:
-    stream1_name = urllib.unquote_plus(params["stream1_name"])
-if "stream2_name" in params:
-    stream2_name = urllib.unquote_plus(params["stream2_name"])
-if "stream3_name" in params:
-    stream3_name = urllib.unquote_plus(params["stream3_name"])
+if "stream_ids" in params:
+    stream_ids = ast.literal_eval(params["stream_ids"])
 if "highlight_id" in params:
     highlight_id = urllib.unquote_plus(params["highlight_id"])
 
@@ -46,7 +31,7 @@ elif mode == 100 or mode == 101:
     todays_games(game_day)
 
 elif mode == 104:
-    stream_select(stream1_id, stream2_id, stream3_id, stream1_name, stream2_name, stream3_name, highlight_id)
+    stream_select(stream_ids, highlight_id)
 
 elif mode == 105:
     # Yesterday"s Games

--- a/resources/lib/game.py
+++ b/resources/lib/game.py
@@ -8,12 +8,7 @@ class Game:
         self.home_team = game_json["homeCompetitor"]
         self.away_team = game_json["awayCompetitor"]
         self.content = game_json["content"]
-        self.stream1_id = ""
-        self.stream2_id = ""
-        self.stream3_id = ""
-        self.stream1_name = ""
-        self.stream2_name = ""
-        self.stream3_name = ""
+        self.stream_ids = {}
         self.highlight_id = ""
 
     def create_listitem(self):
@@ -43,21 +38,11 @@ class Game:
 
         # add_stream(name, '', title, self.home_id, self.away_id, icon, fanart, info, video_info, audio_info)
 
-        add_stream(name, title, icon, fanart, info, stream1_id=self.stream1_id, stream2_id=self.stream2_id, stream3_id=self.stream3_id, \
-                   stream1_name=self.stream1_name, stream2_name=self.stream2_name, stream3_name=self.stream3_name, highlight_id=self.highlight_id)
+        add_stream(name, title, icon, fanart, info, stream_ids=self.stream_ids, highlight_id=self.highlight_id)
 
     def set_ids(self):
         for item in self.content:
             if str(item["contentType"]["name"]).upper() == "FULL GAME" and len(item["clientContentMetadata"]):
-                broadcast = str(item["clientContentMetadata"][0]["name"]).upper()
-                if broadcast == "HOME" or broadcast == "NATIONAL":
-                    self.stream1_id = str(item["id"])
-                    self.stream1_name = broadcast
-                elif broadcast == "AWAY":
-                    self.stream2_id = str(item["id"])
-                    self.stream2_name = broadcast
-                else:
-                    self.stream3_id = str(item["id"])
-                    self.stream3_name = broadcast
+                self.stream_ids[str(item["clientContentMetadata"][0]["name"]).upper()] = str(item["id"])
             elif str(item["contentType"]["name"]).upper() == "HIGHLIGHTS":
                 self.highlight_id = str(item["id"])

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -1,5 +1,5 @@
 import sys
-import re, os, time
+import re, os, time, ast
 import calendar, pytz
 import requests, urllib
 from datetime import datetime, timedelta

--- a/resources/lib/nhl_tv.py
+++ b/resources/lib/nhl_tv.py
@@ -47,36 +47,24 @@ def todays_games(game_day):
 
     add_dir('[B]%s >>[/B]' % LOCAL_STRING(30011), '/live', 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"))
 
-def stream_select(stream1_id, stream2_id, stream3_id, stream1_name, stream2_name, stream3_name, highlight_id):
-    xbmc.log(f"stream1_id: {stream1_id}, stream1_name: {stream1_name}")
-    xbmc.log(f"stream2_id: {stream2_id}, stream2_name: {stream2_name}")
-    xbmc.log(f"stream3_id: {stream3_id}, stream3_name: {stream3_name}")
+def stream_select(stream_ids, highlight_id):
+    for stream_name in stream_ids.keys():
+        xbmc.log(f"stream id for {stream_name}: {stream_ids[stream_name]}")
     xbmc.log(f"highlight_id: {highlight_id}")
 
-    options = []
-    if stream1_id != "":
-        options.append(stream1_name)
-    if stream2_id != "":
-        options.append(stream2_name)
-    if stream3_id != "":
-        options.append(stream3_name)
+    options = list(stream_ids.keys())
     if highlight_id != "":
         options.append("Highlights")
 
     dialog = xbmcgui.Dialog()
     n = dialog.select('Choose Stream', options)
     if n > -1:
-        if options[n] == stream1_name:
-            id = stream1_id
-        elif options[n] == stream2_name:
-            id = stream2_id
-        elif options[n] == stream3_name:
-            id = stream3_id
-        elif options[n] == "Highlights":
+        if options[n] == "Highlights":
             id = highlight_id
+        else:
+            id = stream_ids[options[n]]
     else:
         sys.exit()
-
 
     if options[n] != "Highlights":
         update_user_token()


### PR DESCRIPTION
nhltv can give multiple options for which stream to watch for any given game, and the names given to the streams can vary.

This commit allows any number of streams, each with any stream name, to be presented to the user. It does this by putting the stream names and ids into a dict instead of assigning them to a set number of separate variables.

I have tested it with a number of games, including the three referenced in #53 

Improves on: #52
Resolves: #53