### PR TITLE
Add menu option to play live streams from beginning of stream

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -268,3 +268,11 @@ msgstr ""
 msgctxt "#30391"
 msgid "Please select your favorite team from the addon settings"
 msgstr ""
+
+msgctxt "#30392"
+msgid "Stream"
+msgstr ""
+
+msgctxt "#30393"
+msgid "Play ongoing live games from the start of the stream"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -270,9 +270,9 @@ msgid "Please select your favorite team from the addon settings"
 msgstr ""
 
 msgctxt "#30392"
-msgid "Stream"
+msgid "Playback"
 msgstr ""
 
 msgctxt "#30393"
-msgid "Play ongoing live games from the start of the stream"
+msgid "Start live stream playback from beginning"
 msgstr ""

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -33,6 +33,7 @@ settings = ADDON
 USERNAME = settings.getSetting("username")
 PASSWORD = settings.getSetting("password")
 TIME_FORMAT = settings.getSetting("time_format")
+LIVE_FROM_BEGINNING = settings.getSetting("live_from_beginning")
 
 ROOTDIR = xbmcaddon.Addon().getAddonInfo('path')
 USER_DATA_DIR = os.path.join(xbmc.translatePath("special://userdata"), 'addon_data', ADDON_ID)
@@ -257,6 +258,7 @@ def stream_to_listitem(stream_url):
         listitem.setProperty("inputstream.adaptive.manifest_type", "hls")
         listitem.setProperty("inputstream.adaptive.stream_headers",  'User-Agent=%s' % UA_PC)
         listitem.setProperty("inputstream.adaptive.license_key", '|User-Agent=%s' % UA_PC)
+        listitem.setProperty("inputstream.adaptive.play_timeshift_buffer", LIVE_FROM_BEGINNING)
     else:
         listitem = xbmcgui.ListItem(path=f"{stream_url}|{headers}")
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,4 +9,7 @@
   <category label="30159">
     <setting id="time_format" type="select" label="30200" lvalues="32000|32001" default="0" />
   </category>
+  <category label="30392">
+    <setting id="live_from_beginning" type="bool" label="30393" default="false"/>
+  </category>
 </settings>


### PR DESCRIPTION
Currently if a user starts playback of an in-progress game, the stream starts from wherever the live playback is currently up to. This has a high risk of spoilers.

This PR adds an option to the settings called "Start live stream playback from beginning" under a new submenu called "Playback". This controls a bool which is used to set the inputstream property `inputstream.adaptive.play_timeshift_buffer` which, when set to true, will play any ongoing live streams from the beginning of the stream. (see https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptiveplay_timeshift_buffer )

I originally wanted it to be chosen by the user on a per-stream basis, but that would have been more difficult and would also present the user with yet another dialog to click through when playing a stream which could be annoying. So the approach provided is probably cleaner anyway.